### PR TITLE
Correct import pathing

### DIFF
--- a/bml/lib/update_crdb.py
+++ b/bml/lib/update_crdb.py
@@ -1,9 +1,9 @@
-from lib.util import connect_crdb
+import util
 
 
 def insert_grades_db(config, uuid, test, osp_name, avg_runtime, grade,
                      time_stamp, puddle, dlrn, concurrency, times):
-    conn = connect_crdb(config)
+    conn = util.connect_crdb(config)
     conn.set_session(autocommit=True)
     cur = conn.cursor()
     classify = True
@@ -22,7 +22,7 @@ def insert_grades_db(config, uuid, test, osp_name, avg_runtime, grade,
 
 def insert_values_db(config, uuid, test, osp_name, avg_runtime,
                      time_stamp, puddle, dlrn, concurrency, times):
-    conn = connect_crdb(config)
+    conn = util.connect_crdb(config)
     conn.set_session(autocommit=True)
     cur = conn.cursor()
     classify = False


### PR DESCRIPTION
So the mistake here is that once your in the util folder you can load all the other files using just import <name> because you can always know their going to be top level and together, it's only when your in a different folder that you need to prefix with the full path. 

Or at least that's my understanding, this is one of the python things I don't get perfectly and should probably read up on.